### PR TITLE
Support of MySQL 5.6 and 5.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## dbt-mysql 0.18.0 (Release TBD)
 
 ### Under the hood
+- Support for MySQL 5.6, 5.7, and 8.0 ([#22](https://github.com/fishtown-analytics/dbt-mysql/pull/22), [#22](https://github.com/fishtown-analytics/dbt-mysql/pull/22))
 - Manage MySQL connections via ODBC ([#1](https://github.com/fishtown-analytics/dbt-mysql/pull/1))
 - Pass [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests) ([#3](https://github.com/fishtown-analytics/dbt-mysql/pull/3))
 - Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/fishtown-analytics/dbt-mysql/pull/2), [#12](https://github.com/fishtown-analytics/dbt-mysql/pull/12), [#17](https://github.com/fishtown-analytics/dbt-mysql/pull/17))
 - Add issue templates and CHANGELOG ([#118](https://github.com/fishtown-analytics/dbt-mysql/pull/118))
-- Support for MySQL 5.6, 5.7, and 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,3 +5,4 @@
 - Pass [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests) ([#3](https://github.com/fishtown-analytics/dbt-mysql/pull/3))
 - Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/fishtown-analytics/dbt-mysql/pull/2), [#12](https://github.com/fishtown-analytics/dbt-mysql/pull/12), [#17](https://github.com/fishtown-analytics/dbt-mysql/pull/17))
 - Add issue templates and CHANGELOG ([#118](https://github.com/fishtown-analytics/dbt-mysql/pull/118))
+- Support for MySQL 5.6, 5.7, and 8.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,8 @@
 ## dbt-mysql 0.18.0 (Release TBD)
 
 ### Under the hood
-- Support for MySQL 5.6, 5.7, and 8.0 ([#24](https://github.com/fishtown-analytics/dbt-mysql/pull/24))
-- Manage MySQL connections via ODBC ([#1](https://github.com/fishtown-analytics/dbt-mysql/pull/1))
-- Pass [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests) ([#3](https://github.com/fishtown-analytics/dbt-mysql/pull/3))
-- Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/fishtown-analytics/dbt-mysql/pull/2), [#12](https://github.com/fishtown-analytics/dbt-mysql/pull/12), [#17](https://github.com/fishtown-analytics/dbt-mysql/pull/17))
-- Add issue templates and CHANGELOG ([#118](https://github.com/fishtown-analytics/dbt-mysql/pull/118))
+- Support for MySQL 5.6, 5.7, and 8.0 ([#24](https://github.com/dbeatty10/dbt-mysql/pull/24))
+- Manage MySQL connections via ODBC ([#1](https://github.com/dbeatty10/dbt-mysql/pull/1))
+- Pass [dbt-adapter-tests](https://github.com/dbeatty10/dbt-adapter-tests) ([#3](https://github.com/dbeatty10/dbt-mysql/pull/3))
+- Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/dbeatty10/dbt-mysql/pull/2), [#12](https://github.com/dbeatty10/dbt-mysql/pull/12), [#17](https://github.com/dbeatty10/dbt-mysql/pull/17))
+- Add issue templates and CHANGELOG ([#118](https://github.com/dbeatty10/dbt-mysql/pull/118))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,4 +5,4 @@
 - Manage MySQL connections via ODBC ([#1](https://github.com/dbeatty10/dbt-mysql/pull/1))
 - Pass [dbt-adapter-tests](https://github.com/dbeatty10/dbt-adapter-tests) ([#3](https://github.com/dbeatty10/dbt-mysql/pull/3))
 - Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/dbeatty10/dbt-mysql/pull/2), [#12](https://github.com/dbeatty10/dbt-mysql/pull/12), [#17](https://github.com/dbeatty10/dbt-mysql/pull/17))
-- Add issue templates and CHANGELOG ([#118](https://github.com/dbeatty10/dbt-mysql/pull/118))
+- Add issue templates and CHANGELOG ([#18](https://github.com/dbeatty10/dbt-mysql/pull/18))

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## dbt-mysql 0.18.0 (Release TBD)
 
 ### Under the hood
-- Support for MySQL 5.6, 5.7, and 8.0 ([#22](https://github.com/fishtown-analytics/dbt-mysql/pull/22), [#22](https://github.com/fishtown-analytics/dbt-mysql/pull/22))
+- Support for MySQL 5.6, 5.7, and 8.0 ([#24](https://github.com/fishtown-analytics/dbt-mysql/pull/24))
 - Manage MySQL connections via ODBC ([#1](https://github.com/fishtown-analytics/dbt-mysql/pull/1))
 - Pass [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests) ([#3](https://github.com/fishtown-analytics/dbt-mysql/pull/3))
 - Apache 2.0 license and instructions for project contributors, README, and release instructions ([#2](https://github.com/fishtown-analytics/dbt-mysql/pull/2), [#12](https://github.com/fishtown-analytics/dbt-mysql/pull/12), [#17](https://github.com/fishtown-analytics/dbt-mysql/pull/17))

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 This plugin ports [dbt](https://getdbt.com) functionality to MySQL 8.0.
 
 This is an experimental plugin:
-- We have not tested it against older versions of MySQL or storage engines other than the default of InnoDB
+- We have not tested it extensively or with storage engines other than the default of InnoDB
+- MariaDB compatibility is untested
 - Compatiblity with other [dbt packages](https://hub.getdbt.com/) (like [dbt_utils](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/)) is also untested
 
 Please read these docs carefully and use at your own risk. [Issues](https://github.com/dbeatty10/dbt-mysql/issues/new) and [PRs](https://github.com/dbeatty10/dbt-mysql/blob/main/CONTRIBUTING.rst#contributing) welcome!
@@ -19,7 +20,7 @@ dbt-mysql creates connections via an ODBC driver that requires [`pyodbc`](https:
 
 See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about installing `pyodbc`.
 
-### Supported features
+### Supported features for MySQL 8.0
 
 | Supported? | Feature                           |
 | ---------- | --------------------------------- |
@@ -32,6 +33,23 @@ See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about insta
 | ✅         | Custom data tests                 |
 | ✅         | Docs generate                     |
 | ✅         | Snapshots                         |
+
+### Supported features for MySQL 5.6 and 5.7
+
+| Supported? | Feature                           |
+| ---------- | --------------------------------- |
+| ✅         | Table materialization             |
+| ✅         | View materialization              |
+| ✅         | Incremental materialization       |
+| ❌         | Ephemeral materialization         |
+| ✅         | Seeds                             |
+| ✅         | Sources                           |
+| ✅         | Custom data tests                 |
+| ✅         | Docs generate                     |
+| ✅         | Snapshots                         |
+
+Ephemeral materializations rely upon Common Table Expressions (CTE), which is
+not supported until MySQL 8.0
 
 ### Configuring your profile
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,8 @@ Table of Contents
 
    * [Installation](#installation)
    * [Supported features](#supported-features)
-         * [MySQL 8.0](#supported-features)
-         * [MySQL 5.6 and 5.7](#supported-features)
+      * [MySQL 8.0](#supported-features)
+      * [MySQL 5.6 and 5.7](#supported-features)
          * [MySQL 5.6 configuration gotchas](#supported-features)
          * [MySQL 5.7 configuration gotchas](#supported-features)
    * [Configuring your profile](#configuring-your-profile)

--- a/README.md
+++ b/README.md
@@ -1,13 +1,29 @@
 # dbt-mysql
 
-This plugin ports [dbt](https://getdbt.com) functionality to MySQL 8.0.
+This plugin ports [dbt](https://getdbt.com) functionality to MySQL.
 
 This is an experimental plugin:
-- We have not tested it extensively or with storage engines other than the default of InnoDB
+- We have not tested it extensively
+- Storage engines other than the default of InnoDB are untested
 - MariaDB compatibility is untested
+- Only tested with [dbt-adapter-tests](https://github.com/fishtown-analytics/dbt-adapter-tests) with MySQL 5.6, 5.7, and 8.0
 - Compatiblity with other [dbt packages](https://hub.getdbt.com/) (like [dbt_utils](https://hub.getdbt.com/fishtown-analytics/dbt_utils/latest/)) is also untested
 
 Please read these docs carefully and use at your own risk. [Issues](https://github.com/dbeatty10/dbt-mysql/issues/new) and [PRs](https://github.com/dbeatty10/dbt-mysql/blob/main/CONTRIBUTING.rst#contributing) welcome!
+
+Table of Contents
+=================
+
+   * [Installation](#installation)
+   * [Supported features](#supported-features)
+         * [MySQL 8.0](#supported-features)
+         * [MySQL 5.6 and 5.7](#supported-features)
+         * [MySQL 5.6 configuration gotchas](#supported-features)
+         * [MySQL 5.7 configuration gotchas](#supported-features)
+   * [Configuring your profile](#configuring-your-profile)
+   * [Notes](#notes)
+   * [Running Tests](#running-tests)
+   * [Reporting bugs and contributing code](#reporting-bugs-and-contributing-code)
 
 ### Installation
 This plugin can be installed via pip:
@@ -20,7 +36,9 @@ dbt-mysql creates connections via an ODBC driver that requires [`pyodbc`](https:
 
 See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about installing `pyodbc`.
 
-### Supported features for MySQL 8.0
+### Supported features
+
+#### MySQL 8.0
 
 | Supported? | Feature                           |
 | ---------- | --------------------------------- |
@@ -34,7 +52,7 @@ See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about insta
 | ✅         | Docs generate                     |
 | ✅         | Snapshots                         |
 
-### Supported features for MySQL 5.6 and 5.7
+#### MySQL 5.6 and 5.7
 
 | Supported? | Feature                           |
 | ---------- | --------------------------------- |
@@ -46,10 +64,40 @@ See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about insta
 | ✅         | Sources                           |
 | ✅         | Custom data tests                 |
 | ✅         | Docs generate                     |
-| ✅         | Snapshots                         |
+| 🤷         | Snapshots                         |
 
-Ephemeral materializations rely upon Common Table Expressions (CTE), which is
+Notes:
+- Ephemeral materializations rely upon Common Table Expressions (CTE), which is
 not supported until MySQL 8.0
+- MySQL 5.6 and 5.7 have some configuration gotchas that affect snapshots (see below).
+
+##### MySQL 5.6 configuration gotchas
+
+dbt snapshots might not work properly due to [automatic initialization and updating for `TIMESTAMP`](https://dev.mysql.com/doc/refman/5.6/en/timestamp-initialization.html) if:
+- the output of `SHOW VARIABLES LIKE 'sql_mode'` includes `NO_ZERO_DATE`
+- the output of `SHOW GLOBAL VARIABLES LIKE 'explicit_defaults_for_timestamp'` has a value of `OFF`
+
+A solution is to include the following in a `*.cnf` file:
+Configuration to include in a `*.cnf` file:
+```
+[mysqld]
+explicit_defaults_for_timestamp = true
+```
+
+##### MySQL 5.7 configuration gotchas
+
+dbt snapshots might not work properly due to [automatic initialization and updating for `TIMESTAMP`](https://dev.mysql.com/doc/refman/5.7/en/timestamp-initialization.html) if:
+dbt snapshots might not work properly if:
+- the output of `SHOW VARIABLES LIKE 'sql_mode'` includes `NO_ZERO_DATE`
+
+A solution is to include the following in a `*.cnf` file:
+Configuration to include in a `*.cnf` file:
+```
+[mysqld]
+explicit_defaults_for_timestamp = true
+sql_mode = "ALLOW_INVALID_DATES,{other_sql_modes}"
+```
+where `{other_sql_modes}` is the rest of the modes from the `SHOW VARIABLES LIKE 'sql_mode'` output.
 
 ### Configuring your profile
 
@@ -114,7 +162,7 @@ dbt-mysql borrows from [dbt-spark](https://github.com/fishtown-analytics/dbt-spa
 
 ### Running Tests
 
-1. Modify `test/mysql.dbtspec` with your `server`, `username`, and `password`
+1. Modify `test/mysql.dbtspec` with your `server`, `username`, `password`, and (optionally) `port`
 1. Install the `pytest-dbt-adapter` package
 1. Run the test specs in this repository
 

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -18,6 +18,7 @@ from dbt.logger import GLOBAL_LOGGER as logger
 class MySQLCredentials(Credentials):
     driver: str
     server: str
+    port: Optional[int]
     database: Optional[str]
     schema: str
     username: Optional[str]
@@ -54,6 +55,10 @@ class MySQLCredentials(Credentials):
         parts.append(f"DRIVER={{{self.driver}}}")
         parts.append(f"SERVER={self.server}")
         parts.append(f"UID={self.username}")
+
+        if self.port:
+            parts.append(f"PORT={self.port}")
+
         if mask:
             parts.append("PWD=*********")
         else:
@@ -70,6 +75,7 @@ class MySQLCredentials(Credentials):
         """
         return (
             "server",
+            "port",
             "database",
             "schema",
             "user",

--- a/dbt/include/mysql/macros/adapters.sql
+++ b/dbt/include/mysql/macros/adapters.sql
@@ -39,9 +39,7 @@
 
   create {% if temporary: -%}temporary{%- endif %} table
     {{ relation.include(database=False) }}
-  as (
     {{ sql }}
-  )
 {% endmacro %}
 
 {% macro mysql__current_timestamp() -%}

--- a/dbt/include/mysql/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/mysql/macros/materializations/snapshot/snapshot.sql
@@ -137,3 +137,77 @@
     {%- endfor -%}
     {{ return([ns.column_added, intersection]) }}
 {%- endmacro %}
+
+{% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}
+
+    select
+        'insert' as dbt_change_type,
+        source_data.*
+
+    from (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            {{ strategy.updated_at }} as dbt_updated_at,
+            {{ strategy.updated_at }} as dbt_valid_from,
+            nullif({{ strategy.updated_at }}, {{ strategy.updated_at }}) as dbt_valid_to,
+            {{ strategy.scd_id }} as dbt_scd_id
+
+        from (
+            {{ source_sql }}
+        ) as snapshot_query
+
+    ) as source_data
+    left outer join (
+
+        select *,
+            {{ strategy.unique_key }} as dbt_unique_key
+
+        from {{ target_relation }}
+
+    ) as snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+    where snapshotted_data.dbt_unique_key is null
+       or (
+            snapshotted_data.dbt_unique_key is not null
+        and snapshotted_data.dbt_valid_to is null
+        and (
+            {{ strategy.row_changed }}
+        )
+    )
+
+    union all
+
+    select
+        'update' as dbt_change_type,
+        source_data.*,
+        snapshotted_data.dbt_scd_id
+
+    from (
+
+        select
+            *,
+            {{ strategy.unique_key }} as dbt_unique_key,
+            {{ strategy.updated_at }} as dbt_updated_at,
+            {{ strategy.updated_at }} as dbt_valid_from,
+            {{ strategy.updated_at }} as dbt_valid_to
+
+        from (
+            {{ source_sql }}
+        ) as snapshot_query
+
+    ) as source_data
+    join (
+
+        select *,
+            {{ strategy.unique_key }} as dbt_unique_key
+
+        from {{ target_relation }}
+
+    ) as snapshotted_data on snapshotted_data.dbt_unique_key = source_data.dbt_unique_key
+    where snapshotted_data.dbt_valid_to is null
+    and (
+        {{ strategy.row_changed }}
+    )
+
+{%- endmacro %}

--- a/dbt/include/mysql/sample_profiles.yml
+++ b/dbt/include/mysql/sample_profiles.yml
@@ -4,6 +4,7 @@ default:
     dev:
       type: mysql
       server: [server/host]
+      port: [port]  # optional
       schema: [schema]
       username: [username]
       password: [password]
@@ -11,6 +12,7 @@ default:
     prod:
       type: mysql
       server: [server/host]
+      port: [port]  # optional
       schema: [schema]
       username: [username]
       password: [password]


### PR DESCRIPTION
resolves #21
resolves #22

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description

<!--- Describe the Pull Request here -->
Versions of MySQL prior to 8.0 do not support Common Table Expressions (CTE).

The effects are:
- ephemeral materializations aren't supported for MySQL 5.6 and 5.7
- code using CTE needed conversion to subqueries instead

MySQL 5.6 reaches the official end of support in Feb 2021. MySQL 5.7 reaches the end of support in Oct 2023.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
