### PR TITLE
Replace pyodbc with mysql-connector-python

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,5 @@
-## dbt-mysql 0.18.1 (Release TBD)
+## dbt-mysql 0.18.0.1 (Release TBD)
+- Manage MySQL connections via a self-contained DB API 2.0 compliant Python driver (instead of ODBC) ([#40](https://github.com/dbeatty10/dbt-mysql/pull/40))
 
 ## dbt-mysql 0.18.0 (December 6, 2020)
 

--- a/README.md
+++ b/README.md
@@ -32,10 +32,6 @@ This plugin can be installed via pip:
 $ pip install dbt-mysql
 ```
 
-dbt-mysql creates connections via an ODBC driver that requires [`pyodbc`](https://github.com/mkleehammer/pyodbc).
-
-See https://github.com/mkleehammer/pyodbc/wiki/Install for more info about installing `pyodbc`.
-
 ### Supported features
 
 #### MySQL 8.0

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -1,22 +1,18 @@
-import time
 from contextlib import contextmanager
-from dataclasses import dataclass
-from typing import Any
-from typing import Optional
-from typing import Tuple
+
+import mysql.connector
 
 import dbt.exceptions
-import pyodbc
 from dbt.adapters.sql import SQLConnectionManager
 from dbt.contracts.connection import Connection
-from dbt.contracts.connection import ConnectionState
 from dbt.contracts.connection import Credentials
 from dbt.logger import GLOBAL_LOGGER as logger
+from dataclasses import dataclass
+from typing import Optional
 
 
 @dataclass
 class MySQLCredentials(Credentials):
-    driver: str
     server: str
     port: Optional[int]
     database: Optional[str]
@@ -50,25 +46,6 @@ class MySQLCredentials(Credentials):
     def type(self):
         return "mysql"
 
-    def connection_string(self, mask: bool = False):
-        parts = []
-        parts.append(f"DRIVER={{{self.driver}}}")
-        parts.append(f"SERVER={self.server}")
-        parts.append(f"UID={self.username}")
-
-        if self.port:
-            parts.append(f"PORT={self.port}")
-
-        if mask:
-            parts.append("PWD=*********")
-        else:
-            parts.append(f"PWD={self.password}")
-
-        if self.charset:
-            parts.append(f"charset={self.charset}")
-
-        return ";".join(parts)
-
     def _connection_keys(self):
         """
         Returns an iterator of keys to pretty-print in 'dbt debug'
@@ -86,118 +63,72 @@ class MySQLConnectionManager(SQLConnectionManager):
     TYPE = "mysql"
 
     @classmethod
-    def open(cls, connection: Connection):
-        if connection.state == ConnectionState.OPEN:
-            logger.debug("Connection is already open, skipping open.")
+    def open(cls, connection):
+        if connection.state == 'open':
+            logger.debug('Connection is already open, skipping open.')
             return connection
 
+        credentials = cls.get_credentials(connection.credentials)
+        kwargs = {}
+
+        kwargs["host"] = credentials.server
+        kwargs["user"] = credentials.username
+        kwargs["passwd"] = credentials.password
+
+        if credentials.port:
+            kwargs["port"] = credentials.port
+
         try:
-            connection.handle = pyodbc.connect(
-                connection.credentials.connection_string(), autocommit=True,
-            )
-
-            # MySQL tends to use a single encoding and does not differentiate
-            # between "SQL_CHAR" and "SQL_WCHAR". Therefore when using its ODBC
-            # drivers we must configure the connection to encode Unicode data
-            # as UTF-8 and to decode both C buffer types using UTF-8.
-            # See: https://github.com/mkleehammer/pyodbc/wiki/Unicode#mysql-and-postgresql
-            connection.handle.setdecoding(pyodbc.SQL_CHAR, encoding='utf-8')
-            connection.handle.setdecoding(pyodbc.SQL_WCHAR, encoding='utf-8')
-            connection.handle.setencoding(encoding='utf-8')
-
-            connection.state = ConnectionState.OPEN
-        except pyodbc.OperationalError as e:
-            logger.debug(
-                f"Got an error when attempting to open an odbc connection: '{e}'"
-            )
+            connection.handle = mysql.connector.connect(**kwargs)
+            connection.state = 'open'
+        except mysql.connector.Error as e:
+            logger.debug("Got an error when attempting to open a mysql "
+                         "connection: '{}'"
+                         .format(e))
 
             connection.handle = None
-            connection.state = ConnectionState.FAIL
+            connection.state = 'fail'
 
-            raise dbt.exceptions.FailedToConnectException(str(e)) from e
+            raise dbt.exceptions.FailedToConnectException(str(e))
 
         return connection
+
+    @classmethod
+    def get_credentials(cls, credentials):
+        return credentials
 
     def cancel(self, connection: Connection):
         connection.handle.close()
 
-    def add_query(
-        self,
-        sql: str,
-        auto_begin: bool = True,
-        bindings: Optional[Any] = None,
-        abridge_sql_log: bool = False,
-    ) -> Tuple[Connection, Any]:
-        connection = self.get_thread_connection()
-        if auto_begin and connection.transaction_open is False:
-            self.begin()
-
-        logger.debug(f'Using {self.TYPE} connection "{connection.name}".')
-
-        with self.exception_handler(sql):
-            if abridge_sql_log:
-                log_sql = "{}...".format(sql[:512])
-            else:
-                log_sql = sql
-
-            logger.debug(
-                "On {connection_name}: {sql}",
-                connection_name=connection.name,
-                sql=log_sql,
-            )
-            pre = time.time()
-
-            cursor = connection.handle.cursor()
-
-            # PyODBC returns an error if bindings are passed in and there
-            # aren't any parameter markers in the query.
-            # We can get rid of this override when this issue is fixed:
-            # https://github.com/fishtown-analytics/dbt/issues/1627
-            if bindings is None:
-                cursor.execute(sql)
-            else:
-                cursor.execute(sql, bindings)
-
-            logger.debug(
-                "SQL status: {status} in {elapsed:0.2f} seconds",
-                status=self.get_status(cursor),
-                elapsed=(time.time() - pre),
-            )
-
-            return connection, cursor
-
     @contextmanager
-    def exception_handler(self, sql: str):
+    def exception_handler(self, sql):
         try:
             yield
-        except pyodbc.OperationalError as e:
-            logger.debug(f"pyodbc OperationalError: {e}")
+
+        except mysql.connector.DatabaseError as e:
+            logger.debug('MySQL error: {}'.format(str(e)))
 
             try:
-                self.release()
-            except pyodbc.Error as e:
-                logger.debug(f"Failed to release connection! {e}")
+                self.rollback_if_open()
+            except mysql.connector.Error:
+                logger.debug("Failed to release connection!")
+                pass
 
-            raise dbt.exceptions.DatabaseException from e
+            raise dbt.exceptions.DatabaseException(str(e).strip()) from e
+
         except Exception as e:
-            logger.debug(f"Error running SQL: {sql}")
+            logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
-            self.release()
+            self.rollback_if_open()
             if isinstance(e, dbt.exceptions.RuntimeException):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
-            raise dbt.exceptions.RuntimeException(str(e)) from e
+
+            raise dbt.exceptions.RuntimeException(e) from e
 
     @classmethod
     def get_status(cls, cursor):
-        # There's no real way to get this from pyodbc, so just return "OK"
+        # There's no real way to get this from mysql-connector-python, so just return "OK"
         return "OK"
-
-    # pyodbc automatically handles transactions with the cursor
-    def add_begin_query(self):
-        pass
-
-    def add_commit_query(self):
-        pass

--- a/dbt/include/mysql/macros/materializations/seed/seed.sql
+++ b/dbt/include/mysql/macros/materializations/seed/seed.sql
@@ -16,7 +16,7 @@
             insert into {{ this.render() }} ({{ cols_sql }}) values
             {% for row in chunk -%}
                 ({%- for column in agate_table.column_names -%}
-                    ?
+                    %s
                     {%- if not loop.last%},{%- endif %}
                 {%- endfor -%})
                 {%- if not loop.last%},{%- endif %}

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ setup(
     },
     install_requires=[
         "dbt-core~=0.18.0",
-        "pyodbc",
+        "mysql-connector-python~=8.0.22",
     ],
     classifiers=[
         'Development Status :: 3 - Alpha',


### PR DESCRIPTION
resolves #37

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description

Replace pyodbc with mysql-connector-python.

This introduces a DB API 2.0 compliant Python driver and removes the need to install an external ODBC driver in the environment.

### Checklist

Note: tested against a locally-modified version of pytest-dbt-adapter that still need to be added to an external repo (#39)
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
