### PR TITLE
Fix URL with incorrect branch name

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -21,7 +21,7 @@ pytest test/mysql.dbtspec
 
 The official `pytest-dbt-adapter` package from Fishtown Analytics uses some SQL syntax not supported by MySQL.
 
-This fork (and branch) contains the necessary changes: https://github.com/dbeatty10/dbt-adapter-tests/tree/mysql
+This fork (and branch) contains the necessary changes: https://github.com/dbeatty10/dbt-adapter-tests/tree/dbt-mysql-0.19.0
 
 #### Install via SSH
 


### PR DESCRIPTION
### Description

The GitHUb URL for custom `dbt-adapter-tests` contained the incorrect branch name.

### Checklist
 - [x] This PR includes tests, or tests are not required/relevant for this PR
