### PR TITLE
Add a `database` arg to the `connect` call

### DIFF
--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -75,7 +75,8 @@ class MySQLConnectionManager(SQLConnectionManager):
         kwargs["host"] = credentials.server
         kwargs["user"] = credentials.username
         kwargs["passwd"] = credentials.password
-
+        kwargs["database"] = credentials.schema
+        
         if credentials.port:
             kwargs["port"] = credentials.port
 


### PR DESCRIPTION
resolves #56 

### Description

Adds a `database` arg based on `credentials.schema` to the values passed to `mysql.connector.connect`; I couldn't get any non-trivial queries to work w/o this.

### Checklist
 - [X ] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
