### PR TITLE
Added optional ssl_disabled property

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ your_profile_name:
       schema: analytics
       username: your_mysql_username
       password: your_mysql_password
+      ssl_disabled: True
 ```
 
 | Option          | Description                                                                         | Required?                                                          | Example                                        |
@@ -107,6 +108,7 @@ your_profile_name:
 | schema          | Specify the schema (database) to build models into                                  | Required                                                           | `analytics`                                    |
 | username        | The username to use to connect to the server                                        | Required                                                           | `dbt_admin`                                    |
 | password        | The password to use for authenticating to the server                                | Required                                                           | `correct-horse-battery-staple`                 |
+| ssl_disabled    | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `True` or `False`                              |
 
 ### Notes
 

--- a/dbt/adapters/mysql5/connections.py
+++ b/dbt/adapters/mysql5/connections.py
@@ -21,6 +21,7 @@ class MySQLCredentials(Credentials):
     username: Optional[str]
     password: Optional[str]
     charset: Optional[str]
+    ssl_disabled: Optional[bool]
 
     _ALIASES = {
         "UID": "username",
@@ -75,6 +76,9 @@ class MySQLConnectionManager(SQLConnectionManager):
         kwargs["host"] = credentials.server
         kwargs["user"] = credentials.username
         kwargs["passwd"] = credentials.password
+
+        if credentials.ssl_disabled:
+            kwargs["ssl_disabled"] = credentials.ssl_disabled
 
         if credentials.port:
             kwargs["port"] = credentials.port


### PR DESCRIPTION
### Feature

Ability to set optional property ssl_disabled during MySql 5.x connection initialization.

### Description

MySql 5.x comes by default with SSL enabled for TLS connectivity. For development purposes, it is handy to disable this property by setting ssl_disabled to True. 


### Checklist
 - [x] I have run this code in development and it appears to offer the stated
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [ ] I have updated the `CHANGELOG.md` with information about my change
