### PR TITLE
Enable snapshot integration tests for MySQL 5.7 and MariaDB 10.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,8 +43,6 @@ jobs:
           MYSQL_ROOT_PASSWORD: dbt
         command: [--explicit-defaults-for-timestamp=ON]
         name: mysql-server-5-7
-
-
     steps:
       - checkout
       - run:
@@ -66,6 +64,7 @@ jobs:
       - image: mariadb:10.5
         environment:
           MYSQL_ROOT_PASSWORD: dbt
+        command: [--explicit-defaults-for-timestamp=ON]
         name: mariadb-server-10-5
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,8 +41,9 @@ jobs:
       - image: mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: dbt
-        command: [--explicit-defaults-for-timestamp=ON, sql_mode="ALLOW_INVALID_DATES\,ONLY_FULL_GROUP_BY\,STRICT_TRANS_TABLES\,NO_ZERO_IN_DATE\,ERROR_FOR_DIVISION_BY_ZERO\,NO_AUTO_CREATE_USER\,NO_ENGINE_SUBSTITUTION"]
+        command: [--explicit-defaults-for-timestamp=ON]
         name: mysql-server-5-7
+
 
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,9 @@ jobs:
       - image: mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: dbt
+        command: [--explicit-defaults-for-timestamp=ON, sql_mode="ALLOW_INVALID_DATES,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"]
         name: mysql-server-5-7
+
     steps:
       - checkout
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -41,7 +41,7 @@ jobs:
       - image: mysql:5.7
         environment:
           MYSQL_ROOT_PASSWORD: dbt
-        command: [--explicit-defaults-for-timestamp=ON, sql_mode="ALLOW_INVALID_DATES,ONLY_FULL_GROUP_BY,STRICT_TRANS_TABLES,NO_ZERO_IN_DATE,ERROR_FOR_DIVISION_BY_ZERO,NO_AUTO_CREATE_USER,NO_ENGINE_SUBSTITUTION"]
+        command: [--explicit-defaults-for-timestamp=ON, sql_mode="ALLOW_INVALID_DATES\,ONLY_FULL_GROUP_BY\,STRICT_TRANS_TABLES\,NO_ZERO_IN_DATE\,ERROR_FOR_DIVISION_BY_ZERO\,NO_AUTO_CREATE_USER\,NO_ENGINE_SUBSTITUTION"]
         name: mysql-server-5-7
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,10 @@
 ## Unreleased (TBD)
+
+### Under the hood
 - Integration tests for MySQL 5.7 ([#70](https://github.com/dbeatty10/dbt-mysql/issues/70), [#71](https://github.com/dbeatty10/dbt-mysql/pull/71))
 - Integration tests for MariaDB 10.5 ([#72](https://github.com/dbeatty10/dbt-mysql/pull/72))
 - Support for MariaDB 10.5 ([#32](https://github.com/dbeatty10/dbt-mysql/issues/32), [#73](https://github.com/dbeatty10/dbt-mysql/pull/73))
+- Enable snapshot integration tests for MySQL 5.7 and MariaDB 10.5 ([#75](https://github.com/dbeatty10/dbt-mysql/issues/75), [#76](https://github.com/dbeatty10/dbt-mysql/pull/76))
 
 ## dbt-mysql 0.19.0.1 (February 19, 2022)
 - Optional `ssl_disabled` property ([#67](https://github.com/dbeatty10/dbt-mysql/pull/67))

--- a/test/integration/mariadb-10.5.dbtspec
+++ b/test/integration/mariadb-10.5.dbtspec
@@ -17,8 +17,8 @@ sequences:
   test_dbt_base: base
   test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
-  # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
-  # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
   test_dbt_data_test: data_test
   test_dbt_schema_test: schema_test
   test_dbt_ephemeral_data_tests: data_test_ephemeral_models

--- a/test/integration/mysql-5.7.dbtspec
+++ b/test/integration/mysql-5.7.dbtspec
@@ -18,9 +18,8 @@ sequences:
   # Ephemeral materializations not supported for MySQL 5.7
   # test_dbt_ephemeral: ephemeral
   test_dbt_incremental: incremental
-  # Snapshot materializations not supported for MySQL 5.7
-  # test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
-  # test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
+  test_dbt_snapshot_strategy_timestamp: snapshot_strategy_timestamp
+  test_dbt_snapshot_strategy_check_cols: snapshot_strategy_check_cols
   test_dbt_data_test: data_test
   test_dbt_schema_test: schema_test
   # Ephemeral materializations not supported for MySQL 5.7


### PR DESCRIPTION
resolves #75

### Description

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
