### PR TITLE
Update to `dbt-tests-adapter`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This plugin ports [dbt](https://getdbt.com) functionality to MySQL and MariaDB.
 This is an experimental plugin:
 - We have not tested it extensively
 - Storage engines other than the default of InnoDB are untested
-- Only tested with [dbt-adapter-tests](https://github.com/dbt-labs/dbt-adapter-tests) with the following:
+- Only tested with [dbt-tests-adapter](https://github.com/dbt-labs/dbt-core/tree/main/tests/adapter) with the following:
   - MySQL 5.7
   - MySQL 8.0
   - MariaDB 10.5

--- a/tests/README.md
+++ b/tests/README.md
@@ -9,15 +9,15 @@ Here are the steps to run the integration tests:
 
 ## Simple example
 
-Assuming the applicable `pytest-dbt-adapter` package is installed and environment variables are set:
+Assuming the applicable `dbt-tests-adapter` package is installed and environment variables are set:
 ```bash
-PYTHONPATH=. pytest tests/functional/adapter/basic/mysql_test.py
+PYTHONPATH=. pytest tests/functional/adapter/test_basic.py
 ```
 
 ## Full example
 
 ### Prerequisites
-- [`pytest-dbt-adapter`](https://github.com/dbt-labs/dbt-adapter-tests) package
+- [`dbt-tests-adapter`](https://github.com/dbt-labs/dbt-core/tree/main/tests/adapter) package
 
 ### Environment variables
 


### PR DESCRIPTION
resolves #126

### Description

There were some remaining pieces accidentally referring to `pytest-dbt-adapter`. Update all relevant instructions to `dbt-tests-adapter`.

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] ~This PR includes tests, or~ tests are not required/relevant for this PR
 - [x] ~I have updated the `CHANGELOG.md` with information about my change~
