### PR TITLE
Remove customized `snapshot_check_all_get_existing_columns` macro

### DIFF
--- a/dbt/include/mariadb/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/mariadb/macros/materializations/snapshot/snapshot.sql
@@ -114,29 +114,6 @@
 
 {% endmaterialization %}
 
-{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}
-    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}
-    {%- if not target_exists -%}
-        {# no table yet -> return whatever the query does #}
-        {{ return([false, query_columns]) }}
-    {%- endif -%}
-    {# handle any schema changes #}
-    {%- set target_table = node.get('alias', node.get('name')) -%}
-    {%- set target_relation = adapter.get_relation(database=None, schema=node.schema, identifier=target_table) -%}
-    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}
-    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
-    {%- set ns.column_added = false -%}
-
-    {%- set intersection = [] -%}
-    {%- for col in query_columns -%}
-        {%- if col in existing_cols -%}
-            {%- do intersection.append(col) -%}
-        {%- else -%}
-            {% set ns.column_added = true %}
-        {%- endif -%}
-    {%- endfor -%}
-    {{ return([ns.column_added, intersection]) }}
-{%- endmacro %}
 
 {% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}
 

--- a/dbt/include/mysql/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/mysql/macros/materializations/snapshot/snapshot.sql
@@ -113,27 +113,3 @@
   {{ return({'relations': [target_relation]}) }}
 
 {% endmaterialization %}
-
-{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}
-    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}
-    {%- if not target_exists -%}
-        {# no table yet -> return whatever the query does #}
-        {{ return([false, query_columns]) }}
-    {%- endif -%}
-    {# handle any schema changes #}
-    {%- set target_table = node.get('alias', node.get('name')) -%}
-    {%- set target_relation = adapter.get_relation(database=None, schema=node.schema, identifier=target_table) -%}
-    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}
-    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
-    {%- set ns.column_added = false -%}
-
-    {%- set intersection = [] -%}
-    {%- for col in query_columns -%}
-        {%- if col in existing_cols -%}
-            {%- do intersection.append(col) -%}
-        {%- else -%}
-            {% set ns.column_added = true %}
-        {%- endif -%}
-    {%- endfor -%}
-    {{ return([ns.column_added, intersection]) }}
-{%- endmacro %}

--- a/dbt/include/mysql5/macros/materializations/snapshot/snapshot.sql
+++ b/dbt/include/mysql5/macros/materializations/snapshot/snapshot.sql
@@ -114,30 +114,6 @@
 
 {% endmaterialization %}
 
-{% macro snapshot_check_all_get_existing_columns(node, target_exists) -%}
-    {%- set query_columns = get_columns_in_query(node['compiled_sql']) -%}
-    {%- if not target_exists -%}
-        {# no table yet -> return whatever the query does #}
-        {{ return([false, query_columns]) }}
-    {%- endif -%}
-    {# handle any schema changes #}
-    {%- set target_table = node.get('alias', node.get('name')) -%}
-    {%- set target_relation = adapter.get_relation(database=None, schema=node.schema, identifier=target_table) -%}
-    {%- set existing_cols = get_columns_in_query('select * from ' ~ target_relation) -%}
-    {%- set ns = namespace() -%} {# handle for-loop scoping with a namespace #}
-    {%- set ns.column_added = false -%}
-
-    {%- set intersection = [] -%}
-    {%- for col in query_columns -%}
-        {%- if col in existing_cols -%}
-            {%- do intersection.append(col) -%}
-        {%- else -%}
-            {% set ns.column_added = true %}
-        {%- endif -%}
-    {%- endfor -%}
-    {{ return([ns.column_added, intersection]) }}
-{%- endmacro %}
-
 {% macro snapshot_staging_table(strategy, source_sql, target_relation) -%}
 
     select

--- a/tests/functional/adapter/test_basic.py
+++ b/tests/functional/adapter/test_basic.py
@@ -9,8 +9,12 @@ from dbt.tests.adapter.basic.test_empty import BaseEmpty
 from dbt.tests.adapter.basic.test_ephemeral import BaseEphemeral
 from dbt.tests.adapter.basic.test_incremental import BaseIncremental
 from dbt.tests.adapter.basic.test_generic_tests import BaseGenericTests
-from dbt.tests.adapter.basic.test_snapshot_check_cols import BaseSnapshotCheckCols
-from dbt.tests.adapter.basic.test_snapshot_timestamp import BaseSnapshotTimestamp
+from dbt.tests.adapter.basic.test_snapshot_check_cols import (
+    BaseSnapshotCheckCols,
+)
+from dbt.tests.adapter.basic.test_snapshot_timestamp import (
+    BaseSnapshotTimestamp,
+)
 from dbt.tests.adapter.basic.test_adapter_methods import BaseAdapterMethod
 from dbt.tests.util import run_dbt, check_relations_equal
 
@@ -47,8 +51,6 @@ class TestGenericTestsMySQL(BaseGenericTests):
     pass
 
 
-# TODO
-@pytest.mark.skip(reason="known failure to fix")
 class TestSnapshotCheckColsMySQL(BaseSnapshotCheckCols):
     pass
 


### PR DESCRIPTION
resolves #134

### Description

The most common reason for customized macros in dbt-mysql is that typical databases have relation names with three parts whereas MySQL has only two. E.g., a fully-qualified table name in Postgres is `database.schema.table` versus `database.table` in MySQL. The missing part in MySQL is the `information_schema` "catalog".

| DBMS               | Fully-qualified relation name | Parts      |
| ------------------ | ----------------------------- | ---------- |
| Postgres           |  `database.schema.table`      | 3          |
| MySQL              |  `database.table`             | 2          |

In this particular case, we were able to get rid of one of the customized macros 🎉 

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] ~I have updated the `CHANGELOG.md` with information about my change~
