### PR TITLE
Use the root directory for the tox project to install editable requirements

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ commands = /bin/bash -c '{envpython} -m pytest -v {posargs} tests/unit'
 passenv = DBT_INVOCATION_ENV
 deps =
    -r{toxinidir}/requirements-dev.txt
-   -e.
+   -r{toxinidir}/requirements-editable.txt
 
 [testenv:integration-mysql-8.0]
 basepython = python3.9
@@ -23,7 +23,7 @@ commands = {envpython} -m pytest -v --profile mysql {posargs} tests/functional
 passenv = DBT_INVOCATION_ENV DBT_MYSQL_SERVER_NAME DBT_MYSQL_80_PORT
 deps =
    -r{toxinidir}/requirements-dev.txt
-   -e.
+   -r{toxinidir}/requirements-editable.txt
 
 [testenv:integration-mysql-5.7]
 basepython = python3.9
@@ -31,7 +31,7 @@ commands = {envpython} -m pytest -v --profile mysql5 {posargs} tests/functional
 passenv = DBT_INVOCATION_ENV DBT_MYSQL_SERVER_NAME DBT_MYSQL_57_PORT
 deps =
    -r{toxinidir}/requirements-dev.txt
-   -e.
+   -r{toxinidir}/requirements-editable.txt
 
 [testenv:integration-mariadb-10.5]
 basepython = python3.9
@@ -39,4 +39,4 @@ commands = {envpython} -m pytest -v --profile mariadb {posargs} tests/functional
 passenv = DBT_INVOCATION_ENV DBT_MYSQL_SERVER_NAME DBT_MARIADB_105_PORT
 deps =
   -r{toxinidir}/requirements-dev.txt
-  -e.
+  -r{toxinidir}/requirements-editable.txt


### PR DESCRIPTION
resolves #150

### Description

Use the [root directory for the tox project](https://tox.wiki/en/latest/config.html#toxinidir) (where the configuration file is found) to install editable requirements

### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] Tests are not required/relevant for this PR