### PR TITLE
Support connecting via UNIX sockets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Migrate CircleCI to GitHub Actions ([#120](https://github.com/dbeatty10/dbt-mysql/issues/120))
 - Support dbt v1.4 ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146))
 - Support dbt v1.5 ([#145](https://github.com/dbeatty10/dbt-mysql/issues/145))
+- Support connecting via UNIX sockets ([#164](https://github.com/dbeatty10/dbt-mysql/issues/164))
 
 ### Fixes
 - Fix incremental composite keys ([#144](https://github.com/dbeatty10/dbt-mysql/issues/144))
@@ -12,7 +13,7 @@
 - [@lpezet](https://github.com/lpezet) ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146))
 - [@moszutij](https://github.com/moszutij) ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146), [#144](https://github.com/dbeatty10/dbt-mysql/issues/144))
 - [@wesen](https://github.com/wesen) ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146))
-- [@mwallace582](https://github.com/mwallace582) ([#162](https://github.com/dbeatty10/dbt-mysql/pull/162), [#163](https://github.com/dbeatty10/dbt-mysql/pull/163))
+- [@mwallace582](https://github.com/mwallace582) ([#162](https://github.com/dbeatty10/dbt-mysql/pull/162), [#163](https://github.com/dbeatty10/dbt-mysql/pull/163), [#164](https://github.com/dbeatty10/dbt-mysql/issues/164))
 
 
 ## dbt-mysql 1.1.0 (Feb 5, 2023)

--- a/dbt/adapters/mariadb/connections.py
+++ b/dbt/adapters/mariadb/connections.py
@@ -17,7 +17,8 @@ logger = AdapterLogger("mysql")
 
 @dataclass(init=False)
 class MariaDBCredentials(Credentials):
-    server: str
+    server: Optional[str] = None
+    unix_socket: Optional[str] = None
     port: Optional[int] = None
     database: Optional[str] = None
     schema: str
@@ -62,6 +63,7 @@ class MariaDBCredentials(Credentials):
         """
         return (
             "server",
+            "unix_socket",
             "port",
             "database",
             "schema",
@@ -81,13 +83,17 @@ class MariaDBConnectionManager(SQLConnectionManager):
         credentials = cls.get_credentials(connection.credentials)
         kwargs = {}
 
-        kwargs["host"] = credentials.server
         kwargs["user"] = credentials.username
         kwargs["passwd"] = credentials.password
         kwargs["buffered"] = True
 
         if credentials.ssl_disabled:
             kwargs["ssl_disabled"] = credentials.ssl_disabled
+
+        if credentials.server:
+            kwargs["host"] = credentials.server
+        elif credentials.unix_socket:
+            kwargs["unix_socket"] = credentials.unix_socket
 
         if credentials.port:
             kwargs["port"] = credentials.port

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -17,7 +17,8 @@ logger = AdapterLogger("mysql")
 
 @dataclass(init=False)
 class MySQLCredentials(Credentials):
-    server: str
+    server: Optional[str] = None
+    unix_socket: Optional[str] = None
     port: Optional[int] = None
     database: Optional[str] = None
     schema: str
@@ -61,6 +62,7 @@ class MySQLCredentials(Credentials):
         """
         return (
             "server",
+            "unix_socket",
             "port",
             "database",
             "schema",
@@ -80,10 +82,14 @@ class MySQLConnectionManager(SQLConnectionManager):
         credentials = cls.get_credentials(connection.credentials)
         kwargs = {}
 
-        kwargs["host"] = credentials.server
         kwargs["user"] = credentials.username
         kwargs["passwd"] = credentials.password
         kwargs["buffered"] = True
+
+        if credentials.server:
+            kwargs["host"] = credentials.server
+        elif credentials.unix_socket:
+            kwargs["unix_socket"] = credentials.unix_socket
 
         if credentials.port:
             kwargs["port"] = credentials.port

--- a/dbt/adapters/mysql5/connections.py
+++ b/dbt/adapters/mysql5/connections.py
@@ -17,7 +17,8 @@ logger = AdapterLogger("mysql")
 
 @dataclass(init=False)
 class MySQLCredentials(Credentials):
-    server: str
+    server: Optional[str] = None
+    unix_socket: Optional[str] = None
     port: Optional[int] = None
     database: Optional[str] = None
     schema: str
@@ -62,6 +63,7 @@ class MySQLCredentials(Credentials):
         """
         return (
             "server",
+            "unix_socket",
             "port",
             "database",
             "schema",
@@ -81,13 +83,17 @@ class MySQLConnectionManager(SQLConnectionManager):
         credentials = cls.get_credentials(connection.credentials)
         kwargs = {}
 
-        kwargs["host"] = credentials.server
         kwargs["user"] = credentials.username
         kwargs["passwd"] = credentials.password
         kwargs["buffered"] = True
 
         if credentials.ssl_disabled:
             kwargs["ssl_disabled"] = credentials.ssl_disabled
+
+        if credentials.server:
+            kwargs["host"] = credentials.server
+        elif credentials.unix_socket:
+            kwargs["unix_socket"] = credentials.unix_socket
 
         if credentials.port:
             kwargs["port"] = credentials.port


### PR DESCRIPTION
resolves #164

### Description

With this change, it'll be possible to connect to a MySQL database via _either_ TCP or UNIX sockets.

It's debatable whether tests are required for this PR, as it seems like overkill to increase the complexity of the dockerized databases & integration tests for a trivial feature like this. I'm happy to be overruled on that opinion however.

### Checklist
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] This PR includes tests, or tests are not required/relevant for this PR
 - [X] I have updated the `CHANGELOG.md` with information about my change
