### PR TITLE
Add collation support in profiles.yml / Fix incorrect collation for utf8mb4

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,17 +86,21 @@ your_profile_name:
       username: your_mysql_username
       password: your_mysql_password
       ssl_disabled: True
+      charset: utf8mb4
+      collation: utf8mb4_0900_ai_ci
 ```
 
 | Option          | Description                                                                         | Required?                                                          | Example                                        |
 | --------------- | ----------------------------------------------------------------------------------- | ------------------------------------------------------------------ | ---------------------------------------------- |
-| type            | The specific adapter to use                                                         | Required                                                           | `mysql`, `mysql5` or `mariadb`                            |
+| type            | The specific adapter to use                                                         | Required                                                           | `mysql`, `mysql5` or `mariadb`                 |
 | server          | The server (hostname) to connect to                                                 | Required                                                           | `yourorg.mysqlhost.com`                        |
 | port            | The port to use                                                                     | Optional                                                           | `3306`                                         |
 | schema          | Specify the schema (database) to build models into                                  | Required                                                           | `analytics`                                    |
 | username        | The username to use to connect to the server                                        | Required                                                           | `dbt_admin`                                    |
 | password        | The password to use for authenticating to the server                                | Required                                                           | `correct-horse-battery-staple`                 |
 | ssl_disabled    | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `True` or `False`                              |
+| charset         | Specify charset to be used by a connection                                          | Optional                                                           | `utf8mb4`                                      |
+| collation       | Set to enable or disable TLS connectivity to mysql5.x                               | Optional                                                           | `utf8mb4_0900_ai_ci`                           |
 
 ### Notes
 

--- a/dbt/adapters/mariadb/connections.py
+++ b/dbt/adapters/mariadb/connections.py
@@ -26,6 +26,7 @@ class MariaDBCredentials(Credentials):
     password: Optional[str] = None
     charset: Optional[str] = None
     ssl_disabled: Optional[bool] = None
+    collation: Optional[str] = None
 
     _ALIASES = {
         "UID": "username",
@@ -97,6 +98,12 @@ class MariaDBConnectionManager(SQLConnectionManager):
 
         if credentials.port:
             kwargs["port"] = credentials.port
+
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
+
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -25,6 +25,7 @@ class MySQLCredentials(Credentials):
     username: Optional[str] = None
     password: Optional[str] = None
     charset: Optional[str] = None
+    collation: Optional[str] = None
 
     _ALIASES = {
         "UID": "username",
@@ -93,6 +94,12 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         if credentials.port:
             kwargs["port"] = credentials.port
+
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
+
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/dbt/adapters/mysql5/connections.py
+++ b/dbt/adapters/mysql5/connections.py
@@ -26,6 +26,7 @@ class MySQLCredentials(Credentials):
     password: Optional[str] = None
     charset: Optional[str] = None
     ssl_disabled: Optional[bool] = None
+    collation: Optional[str] = None
 
     _ALIASES = {
         "UID": "username",
@@ -97,6 +98,12 @@ class MySQLConnectionManager(SQLConnectionManager):
 
         if credentials.port:
             kwargs["port"] = credentials.port
+
+        if credentials.charset:
+            kwargs["charset"] = credentials.charset
+
+        if credentials.collation:
+            kwargs["collation"] = credentials.collation
 
         try:
             connection.handle = mysql.connector.connect(**kwargs)

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "mysql-connector-python==8.1",
+        "mysql-connector-python>=8.0.0",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "mysql-connector-python>=8.0.0,<8.2",
+        "mysql-connector-python==8.1",
     ],
     zip_safe=False,
     classifiers=[

--- a/setup.py
+++ b/setup.py
@@ -68,7 +68,7 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
-        "mysql-connector-python>=8.0.0,<8.1",
+        "mysql-connector-python>=8.0.0,<8.2",
     ],
     zip_safe=False,
     classifiers=[


### PR DESCRIPTION
resolves #172

<!---
  Include the number of the issue addressed by this PR above if applicable.
  PRs for code changes without an associated issue *will not be merged*.
  See CONTRIBUTING.rst for more information.

  Example:
    resolves #1234
-->


### Description
1. Bumped mysql-connector-python to 8.1, because previous version was by default using incorrect collation for charset `utf8mb4` which was `utf8mb4_general_ci`. The correct default one is `utf8mb4_0900_ci_ai` and 8.1 version uses it by default.
2. Added support for overriding charset and collation via `profiles.yml` which is useful if someone wants to use different charsets and collations by default
3. Adjusted readme with examples of new settings
4. I've run all the tests and they passed

<!--- Describe the Pull Request here -->


### Checklist
 - [x] I have run this code in development and it appears to resolve the stated issue
 - [x] This PR includes tests, or tests are not required/relevant for this PR
 - [x] I have updated the `CHANGELOG.md` with information about my change
