### PR TITLE
Upgrade/1.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 ## Unreleased (TBD)
 
+## dbt-mysql 1.8.0a1 (May 30, 2026)
+
+### Features
+- Support dbt v1.8 (upgrade branch `upgrade/1.8.0`)
+- Add `dbt-adapters` and `dbt-common` as install dependencies for the adapter package split in dbt 1.8
+
+### Fixes
+- Fix `dbt docs generate` when catalog rows have a null `table_database` (MySQL/MariaDB have no database dimension)
+- Fix unit tests for dbt 1.8 adapter initialization (multiprocessing context)
+
+### Under the hood
+- Migrate imports from `dbt.contracts.*` / `dbt.exceptions` to `dbt.adapters.*` / `dbt_common.*`
+- Refactor credentials to plain dataclasses (align with dbt-adapters)
+- Remove legacy Python `get_catalog(manifest)` overrides; use dbt 1.8 macro-based catalog path
+- Add shared `catalog_filter_table_for_no_database` helper for mysql, mysql5, and mariadb
+- Pin dev dependencies to PyPI packages (`dbt-core~=1.8.0`, `dbt-tests-adapter>=1.8.0`)
+- Fix mypy/flake8 typing issues in adapter `impl.py` and `connections.py`
+
+### Contributors
+- [@aabeds](https://github.com/aabeds)
+
+## dbt-mysql 1.7.0 and earlier (see git history)
+
+The entries below were accumulated before per-version CHANGELOG sections were maintained.
+
 ### Features
 - Migrate CircleCI to GitHub Actions ([#120](https://github.com/dbeatty10/dbt-mysql/issues/120))
 - Support dbt v1.4 ([#146](https://github.com/dbeatty10/dbt-mysql/pull/146))

--- a/dbt/adapters/catalog_filter.py
+++ b/dbt/adapters/catalog_filter.py
@@ -1,0 +1,36 @@
+from typing import Any, FrozenSet, Tuple, cast
+
+import agate
+
+from dbt.adapters.base.impl import _expect_row_value
+from dbt_common.clients.agate_helper import table_from_rows
+
+
+def catalog_filter_table_for_no_database(
+    table: agate.Table, used_schemas: FrozenSet[Tuple[str, str]]
+) -> agate.Table:
+    """Filter catalog rows for adapters without a database dimension.
+
+    MySQL/MariaDB catalog macros return NULL for table_database, and manifest
+    used_schemas may use None for the database component. dbt 1.8's base filter
+    calls .lower() on both sides without null checks.
+    """
+    schemas = frozenset(
+        ((database or "").lower(), schema.lower())
+        for database, schema in used_schemas
+        if schema is not None
+    )
+
+    def test(row: agate.Row) -> bool:
+        table_schema = _expect_row_value("table_schema", row)
+        if table_schema is None:
+            return False
+        table_database = _expect_row_value("table_database", row) or ""
+        return (str(table_database).lower(), str(table_schema).lower()) in schemas
+
+    normalized_table = table_from_rows(
+        list(table.rows),
+        table.column_names,
+        text_only_columns=["table_database", "table_schema", "table_name"],
+    )
+    return cast(agate.Table, cast(Any, normalized_table).where(test))

--- a/dbt/adapters/mariadb/__version__.py
+++ b/dbt/adapters/mariadb/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0"
+version = "1.8.0a1"

--- a/dbt/adapters/mariadb/connections.py
+++ b/dbt/adapters/mariadb/connections.py
@@ -3,19 +3,21 @@ from contextlib import contextmanager
 import mysql.connector
 import mysql.connector.constants
 
-import dbt.exceptions
+from dbt.adapters.contracts.connection import AdapterResponse
+from dbt.adapters.contracts.connection import Connection
+from dbt.adapters.contracts.connection import Credentials
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import AdapterResponse
-from dbt.contracts.connection import Connection
-from dbt.contracts.connection import Credentials
-from dbt.events import AdapterLogger
+from dbt_common.exceptions import DbtDatabaseError
+from dbt_common.exceptions import DbtRuntimeError
 from dataclasses import dataclass
 from typing import Optional, Union
 
 logger = AdapterLogger("mysql")
 
 
-@dataclass(init=False)
+@dataclass
 class MariaDBCredentials(Credentials):
     server: str = ""
     unix_socket: Optional[str] = None
@@ -35,15 +37,10 @@ class MariaDBCredentials(Credentials):
         "host": "server",
     }
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-            self.database = None
-
     def __post_init__(self):
         # Database and schema are treated as the same thing
         if self.database is not None and self.database != self.schema:
-            raise dbt.exceptions.DbtRuntimeError(
+            raise DbtRuntimeError(
                 f"    schema: {self.schema} \n"
                 f"    database: {self.database} \n"
                 f"On MariaDB, database must be omitted"
@@ -128,7 +125,7 @@ class MariaDBConnectionManager(SQLConnectionManager):
                 connection.handle = None
                 connection.state = "fail"
 
-                raise dbt.exceptions.FailedToConnectError(str(e))
+                raise FailedToConnectError(str(e))
 
         return connection
 
@@ -153,19 +150,19 @@ class MariaDBConnectionManager(SQLConnectionManager):
                 logger.debug("Failed to release connection!")
                 pass
 
-            raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
+            raise DbtDatabaseError(str(e).strip()) from e
 
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
             self.rollback_if_open()
-            if isinstance(e, dbt.exceptions.DbtRuntimeError):
+            if isinstance(e, DbtRuntimeError):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.DbtRuntimeError(e) from e
+            raise DbtRuntimeError(e) from e
 
     @classmethod
     def get_response(cls, cursor) -> AdapterResponse:
@@ -186,4 +183,5 @@ class MariaDBConnectionManager(SQLConnectionManager):
     def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:
         field_type_values = mysql.connector.constants.FieldType.desc.values()
         mapping = {code: name for (code, name) in field_type_values}
-        return mapping[type_code]
+        key = int(type_code) if isinstance(type_code, str) else type_code
+        return mapping[key]

--- a/dbt/adapters/mariadb/impl.py
+++ b/dbt/adapters/mariadb/impl.py
@@ -1,23 +1,17 @@
-from concurrent.futures import Future
-from dataclasses import asdict
-from typing import Optional, List, Dict, Any, Iterable, Tuple
+from typing import FrozenSet, Optional, List, Tuple
 import agate
 
-import dbt
-import dbt.exceptions
-
-from dbt.adapters.base.impl import catch_as_completed
-from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.mariadb import MariaDBConnectionManager
-from dbt.adapters.mariadb import MariaDBRelation
-from dbt.adapters.mariadb import MariaDBColumn
-from dbt.adapters.base import BaseRelation
-from dbt.contracts.graph.nodes import ConstraintType
+from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
-from dbt.contracts.graph.manifest import Manifest
-from dbt.clients.agate_helper import DEFAULT_TYPE_TESTER
-from dbt.events import AdapterLogger
-from dbt.utils import executor
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.catalog_filter import catalog_filter_table_for_no_database
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.mariadb.column import MariaDBColumn
+from dbt.adapters.mariadb.connections import MariaDBConnectionManager
+from dbt.adapters.mariadb.relation import MariaDBRelation
+from dbt.adapters.sql import SQLAdapter
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.exceptions import DbtRuntimeError
 
 logger = AdapterLogger("mysql")
 
@@ -44,6 +38,12 @@ class MariaDBAdapter(SQLAdapter):
     }
 
     @classmethod
+    def _catalog_filter_table(
+        cls, table: agate.Table, used_schemas: FrozenSet[Tuple[str, str]]
+    ) -> agate.Table:
+        return catalog_filter_table_for_no_database(table, used_schemas)
+
+    @classmethod
     def date_function(cls):
         return "current_date()"
 
@@ -61,7 +61,7 @@ class MariaDBAdapter(SQLAdapter):
         kwargs = {"schema_relation": schema_relation}
         try:
             results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
-        except dbt.exceptions.DbtRuntimeError as e:
+        except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if f"MariaDB database '{schema_relation}' not found" in errmsg:
                 return []
@@ -73,7 +73,7 @@ class MariaDBAdapter(SQLAdapter):
         relations = []
         for row in results:
             if len(row) != 4:
-                raise dbt.exceptions.DbtRuntimeError(
+                raise DbtRuntimeError(
                     "Invalid value from "
                     f'"mariadb__list_relations_without_caching({kwargs})", '
                     f"got {len(row)} values, expected 4"
@@ -84,20 +84,9 @@ class MariaDBAdapter(SQLAdapter):
 
         return relations
 
-    def get_columns_in_relation(self, relation: MariaDBRelation) -> List[MariaDBColumn]:
-        rows: List[agate.Row] = super().get_columns_in_relation(relation)
-        return self.parse_show_columns(relation, rows)
-
-    def _get_columns_for_catalog(self, relation: MariaDBRelation) -> Iterable[Dict[str, Any]]:
-        columns = self.get_columns_in_relation(relation)
-
-        for column in columns:
-            # convert MariaDBColumns into catalog dicts
-            as_dict = asdict(column)
-            as_dict["column_name"] = as_dict.pop("column", None)
-            as_dict["column_type"] = as_dict.pop("dtype")
-            as_dict["table_database"] = None
-            yield as_dict
+    def get_columns_in_relation(self, relation: BaseRelation) -> List[MariaDBColumn]:  # type: ignore[override]
+        columns: List[BaseColumn] = super().get_columns_in_relation(relation)
+        return self.parse_show_columns(relation, columns)
 
     def get_relation(
         self, database: Optional[str], schema: str, identifier: str
@@ -108,7 +97,7 @@ class MariaDBAdapter(SQLAdapter):
         return super().get_relation(database, schema, identifier)
 
     def parse_show_columns(
-        self, relation: MariaDBRelation, raw_rows: List[agate.Row]
+        self, relation: BaseRelation, raw_columns: List[BaseColumn]
     ) -> List[MariaDBColumn]:
         return [
             MariaDBColumn(
@@ -118,57 +107,12 @@ class MariaDBAdapter(SQLAdapter):
                 table_type=relation.type,
                 table_owner=None,
                 table_stats=None,
-                column=column.column,
+                column=col.column,
                 column_index=idx,
-                dtype=column.dtype,
+                dtype=col.dtype,
             )
-            for idx, column in enumerate(raw_rows)
+            for idx, col in enumerate(raw_columns)
         ]
-
-    def get_catalog(self, manifest: Manifest) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = self._get_catalog_schemas(manifest)
-
-        if len(schema_map) > 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
-            )
-
-        with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = []
-            for info, schemas in schema_map.items():
-                for schema in schemas:
-                    futures.append(
-                        tpe.submit_connected(
-                            self,
-                            schema,
-                            self._get_one_catalog,
-                            info,
-                            [schema],
-                            manifest,
-                        )
-                    )
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
-
-    def _get_one_catalog(
-        self,
-        information_schema,
-        schemas,
-        manifest,
-    ) -> agate.Table:
-        if len(schemas) != 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one schema in mariadb _get_one_catalog, found " f"{schemas}"
-            )
-
-        database = information_schema.database
-        schema = list(schemas)[0]
-
-        columns: List[Dict[str, Any]] = []
-        for relation in self.list_relations(database, schema):
-            logger.debug("Getting table schema for relation {}", str(relation))
-            columns.extend(self._get_columns_for_catalog(relation))  # type: ignore[arg-type]
-        return agate.Table.from_object(columns, column_types=DEFAULT_TYPE_TESTER)
 
     def check_schema_exists(self, database, schema):
         results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
@@ -207,9 +151,7 @@ class MariaDBAdapter(SQLAdapter):
         elif location == "prepend":
             return f"concat({value}, '{add_to}')"
         else:
-            raise dbt.exceptions.DbtRuntimeError(
-                f'Got an unexpected location value of "{location}"'
-            )
+            raise DbtRuntimeError(f'Got an unexpected location value of "{location}"')
 
     def get_rows_different_sql(
         self,

--- a/dbt/adapters/mariadb/relation.py
+++ b/dbt/adapters/mariadb/relation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
-from dbt.exceptions import DbtRuntimeError
+from dbt_common.exceptions import DbtRuntimeError
 
 
 @dataclass

--- a/dbt/adapters/mysql/__version__.py
+++ b/dbt/adapters/mysql/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0"
+version = "1.8.0a1"

--- a/dbt/adapters/mysql/connections.py
+++ b/dbt/adapters/mysql/connections.py
@@ -3,19 +3,21 @@ from contextlib import contextmanager
 import mysql.connector
 import mysql.connector.constants
 
-import dbt.exceptions
+from dbt.adapters.contracts.connection import AdapterResponse
+from dbt.adapters.contracts.connection import Connection
+from dbt.adapters.contracts.connection import Credentials
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import AdapterResponse
-from dbt.contracts.connection import Connection
-from dbt.contracts.connection import Credentials
-from dbt.events import AdapterLogger
+from dbt_common.exceptions import DbtDatabaseError
+from dbt_common.exceptions import DbtRuntimeError
 from dataclasses import dataclass
 from typing import Optional, Union
 
 logger = AdapterLogger("mysql")
 
 
-@dataclass(init=False)
+@dataclass
 class MySQLCredentials(Credentials):
     server: str = ""
     unix_socket: Optional[str] = None
@@ -34,15 +36,10 @@ class MySQLCredentials(Credentials):
         "host": "server",
     }
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-            self.database = None
-
     def __post_init__(self):
         # mysql classifies database and schema as the same thing
         if self.database is not None and self.database != self.schema:
-            raise dbt.exceptions.DbtRuntimeError(
+            raise DbtRuntimeError(
                 f"    schema: {self.schema} \n"
                 f"    database: {self.database} \n"
                 f"On MySQL, database must be omitted or have the same value as"
@@ -124,7 +121,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 connection.handle = None
                 connection.state = "fail"
 
-                raise dbt.exceptions.FailedToConnectError(str(e))
+                raise FailedToConnectError(str(e))
 
         return connection
 
@@ -149,19 +146,19 @@ class MySQLConnectionManager(SQLConnectionManager):
                 logger.debug("Failed to release connection!")
                 pass
 
-            raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
+            raise DbtDatabaseError(str(e).strip()) from e
 
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
             self.rollback_if_open()
-            if isinstance(e, dbt.exceptions.DbtRuntimeError):
+            if isinstance(e, DbtRuntimeError):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.DbtRuntimeError(e) from e
+            raise DbtRuntimeError(e) from e
 
     @classmethod
     def get_response(cls, cursor) -> AdapterResponse:
@@ -182,4 +179,5 @@ class MySQLConnectionManager(SQLConnectionManager):
     def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:
         field_type_values = mysql.connector.constants.FieldType.desc.values()
         mapping = {code: name for (code, name) in field_type_values}
-        return mapping[type_code]
+        key = int(type_code) if isinstance(type_code, str) else type_code
+        return mapping[key]

--- a/dbt/adapters/mysql/impl.py
+++ b/dbt/adapters/mysql/impl.py
@@ -1,23 +1,17 @@
-from concurrent.futures import Future
-from dataclasses import asdict
-from typing import Optional, List, Dict, Any, Iterable, Tuple
+from typing import FrozenSet, Optional, List, Tuple
 import agate
 
-import dbt
-import dbt.exceptions
-
-from dbt.adapters.base.impl import catch_as_completed
-from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.mysql import MySQLConnectionManager
-from dbt.adapters.mysql import MySQLRelation
-from dbt.adapters.mysql import MySQLColumn
-from dbt.adapters.base import BaseRelation
-from dbt.contracts.graph.nodes import ConstraintType
+from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
-from dbt.contracts.graph.manifest import Manifest
-from dbt.clients.agate_helper import DEFAULT_TYPE_TESTER
-from dbt.events import AdapterLogger
-from dbt.utils import executor
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.catalog_filter import catalog_filter_table_for_no_database
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.mysql.column import MySQLColumn
+from dbt.adapters.mysql.connections import MySQLConnectionManager
+from dbt.adapters.mysql.relation import MySQLRelation
+from dbt.adapters.sql import SQLAdapter
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.exceptions import DbtRuntimeError
 
 logger = AdapterLogger("mysql")
 
@@ -44,6 +38,12 @@ class MySQLAdapter(SQLAdapter):
     }
 
     @classmethod
+    def _catalog_filter_table(
+        cls, table: agate.Table, used_schemas: FrozenSet[Tuple[str, str]]
+    ) -> agate.Table:
+        return catalog_filter_table_for_no_database(table, used_schemas)
+
+    @classmethod
     def date_function(cls):
         return "current_date()"
 
@@ -61,7 +61,7 @@ class MySQLAdapter(SQLAdapter):
         kwargs = {"schema_relation": schema_relation}
         try:
             results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
-        except dbt.exceptions.DbtRuntimeError as e:
+        except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if f"MySQL database '{schema_relation}' not found" in errmsg:
                 return []
@@ -73,7 +73,7 @@ class MySQLAdapter(SQLAdapter):
         relations = []
         for row in results:
             if len(row) != 4:
-                raise dbt.exceptions.DbtRuntimeError(
+                raise DbtRuntimeError(
                     "Invalid value from "
                     f'"mysql__list_relations_without_caching({kwargs})", '
                     f"got {len(row)} values, expected 4"
@@ -84,20 +84,9 @@ class MySQLAdapter(SQLAdapter):
 
         return relations
 
-    def get_columns_in_relation(self, relation: MySQLRelation) -> List[MySQLColumn]:
-        rows: List[agate.Row] = super().get_columns_in_relation(relation)
-        return self.parse_show_columns(relation, rows)
-
-    def _get_columns_for_catalog(self, relation: MySQLRelation) -> Iterable[Dict[str, Any]]:
-        columns = self.get_columns_in_relation(relation)
-
-        for column in columns:
-            # convert MySQLColumns into catalog dicts
-            as_dict = asdict(column)
-            as_dict["column_name"] = as_dict.pop("column", None)
-            as_dict["column_type"] = as_dict.pop("dtype")
-            as_dict["table_database"] = None
-            yield as_dict
+    def get_columns_in_relation(self, relation: BaseRelation) -> List[MySQLColumn]:  # type: ignore[override]
+        columns: List[BaseColumn] = super().get_columns_in_relation(relation)
+        return self.parse_show_columns(relation, columns)
 
     def get_relation(
         self, database: Optional[str], schema: str, identifier: str
@@ -108,7 +97,7 @@ class MySQLAdapter(SQLAdapter):
         return super().get_relation(database, schema, identifier)
 
     def parse_show_columns(
-        self, relation: MySQLRelation, raw_rows: List[agate.Row]
+        self, relation: BaseRelation, raw_columns: List[BaseColumn]
     ) -> List[MySQLColumn]:
         return [
             MySQLColumn(
@@ -118,57 +107,12 @@ class MySQLAdapter(SQLAdapter):
                 table_type=relation.type,
                 table_owner=None,
                 table_stats=None,
-                column=column.column,
+                column=col.column,
                 column_index=idx,
-                dtype=column.dtype,
+                dtype=col.dtype,
             )
-            for idx, column in enumerate(raw_rows)
+            for idx, col in enumerate(raw_columns)
         ]
-
-    def get_catalog(self, manifest: Manifest) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = self._get_catalog_schemas(manifest)
-
-        if len(schema_map) > 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
-            )
-
-        with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = []
-            for info, schemas in schema_map.items():
-                for schema in schemas:
-                    futures.append(
-                        tpe.submit_connected(
-                            self,
-                            schema,
-                            self._get_one_catalog,
-                            info,
-                            [schema],
-                            manifest,
-                        )
-                    )
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
-
-    def _get_one_catalog(
-        self,
-        information_schema,
-        schemas,
-        manifest,
-    ) -> agate.Table:
-        if len(schemas) != 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one schema in mysql _get_one_catalog, found " f"{schemas}"
-            )
-
-        database = information_schema.database
-        schema = list(schemas)[0]
-
-        columns: List[Dict[str, Any]] = []
-        for relation in self.list_relations(database, schema):
-            logger.debug("Getting table schema for relation {}", str(relation))
-            columns.extend(self._get_columns_for_catalog(relation))  # type: ignore[arg-type]
-        return agate.Table.from_object(columns, column_types=DEFAULT_TYPE_TESTER)
 
     def check_schema_exists(self, database, schema):
         results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
@@ -205,11 +149,9 @@ class MySQLAdapter(SQLAdapter):
         if location == "append":
             return f"concat({add_to}, '{value}')"
         elif location == "prepend":
-            return f"concat({value}, '{add_to}')"
+            return f"concat('{value}', {add_to})"
         else:
-            raise dbt.exceptions.DbtRuntimeError(
-                f'Got an unexpected location value of "{location}"'
-            )
+            raise DbtRuntimeError(f'Got an unexpected location value of "{location}"')
 
     def get_rows_different_sql(
         self,

--- a/dbt/adapters/mysql/relation.py
+++ b/dbt/adapters/mysql/relation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
-from dbt.exceptions import DbtRuntimeError
+from dbt_common.exceptions import DbtRuntimeError
 
 
 @dataclass

--- a/dbt/adapters/mysql5/__version__.py
+++ b/dbt/adapters/mysql5/__version__.py
@@ -1,1 +1,1 @@
-version = "1.7.0"
+version = "1.8.0a1"

--- a/dbt/adapters/mysql5/connections.py
+++ b/dbt/adapters/mysql5/connections.py
@@ -3,19 +3,21 @@ from contextlib import contextmanager
 import mysql.connector
 import mysql.connector.constants
 
-import dbt.exceptions
+from dbt.adapters.contracts.connection import AdapterResponse
+from dbt.adapters.contracts.connection import Connection
+from dbt.adapters.contracts.connection import Credentials
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.exceptions import FailedToConnectError
 from dbt.adapters.sql import SQLConnectionManager
-from dbt.contracts.connection import AdapterResponse
-from dbt.contracts.connection import Connection
-from dbt.contracts.connection import Credentials
-from dbt.events import AdapterLogger
+from dbt_common.exceptions import DbtDatabaseError
+from dbt_common.exceptions import DbtRuntimeError
 from dataclasses import dataclass
 from typing import Optional, Union
 
 logger = AdapterLogger("mysql")
 
 
-@dataclass(init=False)
+@dataclass
 class MySQLCredentials(Credentials):
     server: str = ""
     unix_socket: Optional[str] = None
@@ -35,15 +37,10 @@ class MySQLCredentials(Credentials):
         "host": "server",
     }
 
-    def __init__(self, **kwargs):
-        for k, v in kwargs.items():
-            setattr(self, k, v)
-            self.database = None
-
     def __post_init__(self):
         # mysql classifies database and schema as the same thing
         if self.database is not None and self.database != self.schema:
-            raise dbt.exceptions.DbtRuntimeError(
+            raise DbtRuntimeError(
                 f"    schema: {self.schema} \n"
                 f"    database: {self.database} \n"
                 f"On MySQL, database must be omitted or have the same value as"
@@ -128,7 +125,7 @@ class MySQLConnectionManager(SQLConnectionManager):
                 connection.handle = None
                 connection.state = "fail"
 
-                raise dbt.exceptions.FailedToConnectError(str(e))
+                raise FailedToConnectError(str(e))
 
         return connection
 
@@ -153,19 +150,19 @@ class MySQLConnectionManager(SQLConnectionManager):
                 logger.debug("Failed to release connection!")
                 pass
 
-            raise dbt.exceptions.DbtDatabaseError(str(e).strip()) from e
+            raise DbtDatabaseError(str(e).strip()) from e
 
         except Exception as e:
             logger.debug("Error running SQL: {}", sql)
             logger.debug("Rolling back transaction.")
             self.rollback_if_open()
-            if isinstance(e, dbt.exceptions.DbtRuntimeError):
+            if isinstance(e, DbtRuntimeError):
                 # during a sql query, an internal to dbt exception was raised.
                 # this sounds a lot like a signal handler and probably has
                 # useful information, so raise it without modification.
                 raise
 
-            raise dbt.exceptions.DbtRuntimeError(e) from e
+            raise DbtRuntimeError(e) from e
 
     @classmethod
     def get_response(cls, cursor) -> AdapterResponse:
@@ -186,4 +183,5 @@ class MySQLConnectionManager(SQLConnectionManager):
     def data_type_code_to_name(cls, type_code: Union[int, str]) -> str:
         field_type_values = mysql.connector.constants.FieldType.desc.values()
         mapping = {code: name for (code, name) in field_type_values}
-        return mapping[type_code]
+        key = int(type_code) if isinstance(type_code, str) else type_code
+        return mapping[key]

--- a/dbt/adapters/mysql5/impl.py
+++ b/dbt/adapters/mysql5/impl.py
@@ -1,23 +1,17 @@
-from concurrent.futures import Future
-from dataclasses import asdict
-from typing import Optional, List, Dict, Any, Iterable, Tuple
+from typing import FrozenSet, Optional, List, Tuple
 import agate
 
-import dbt
-import dbt.exceptions
-
-from dbt.adapters.base.impl import catch_as_completed
-from dbt.adapters.sql import SQLAdapter
-from dbt.adapters.mysql5 import MySQLConnectionManager
-from dbt.adapters.mysql5 import MySQLRelation
-from dbt.adapters.mysql5 import MySQLColumn
-from dbt.adapters.base import BaseRelation
-from dbt.contracts.graph.nodes import ConstraintType
+from dbt.adapters.base.column import Column as BaseColumn
 from dbt.adapters.base.impl import ConstraintSupport
-from dbt.contracts.graph.manifest import Manifest
-from dbt.clients.agate_helper import DEFAULT_TYPE_TESTER
-from dbt.events import AdapterLogger
-from dbt.utils import executor
+from dbt.adapters.base import BaseRelation
+from dbt.adapters.catalog_filter import catalog_filter_table_for_no_database
+from dbt.adapters.events.logging import AdapterLogger
+from dbt.adapters.mysql5.column import MySQLColumn
+from dbt.adapters.mysql5.connections import MySQLConnectionManager
+from dbt.adapters.mysql5.relation import MySQLRelation
+from dbt.adapters.sql import SQLAdapter
+from dbt_common.contracts.constraints import ConstraintType
+from dbt_common.exceptions import DbtRuntimeError
 
 logger = AdapterLogger("mysql")
 
@@ -44,6 +38,12 @@ class MySQLAdapter(SQLAdapter):
     }
 
     @classmethod
+    def _catalog_filter_table(
+        cls, table: agate.Table, used_schemas: FrozenSet[Tuple[str, str]]
+    ) -> agate.Table:
+        return catalog_filter_table_for_no_database(table, used_schemas)
+
+    @classmethod
     def date_function(cls):
         return "current_date()"
 
@@ -61,7 +61,7 @@ class MySQLAdapter(SQLAdapter):
         kwargs = {"schema_relation": schema_relation}
         try:
             results = self.execute_macro(LIST_RELATIONS_MACRO_NAME, kwargs=kwargs)
-        except dbt.exceptions.DbtRuntimeError as e:
+        except DbtRuntimeError as e:
             errmsg = getattr(e, "msg", "")
             if f"MySQL database '{schema_relation}' not found" in errmsg:
                 return []
@@ -73,7 +73,7 @@ class MySQLAdapter(SQLAdapter):
         relations = []
         for row in results:
             if len(row) != 4:
-                raise dbt.exceptions.DbtRuntimeError(
+                raise DbtRuntimeError(
                     "Invalid value from "
                     f'"mysql5__list_relations_without_caching({kwargs})", '
                     f"got {len(row)} values, expected 4"
@@ -84,20 +84,9 @@ class MySQLAdapter(SQLAdapter):
 
         return relations
 
-    def get_columns_in_relation(self, relation: MySQLRelation) -> List[MySQLColumn]:
-        rows: List[agate.Row] = super().get_columns_in_relation(relation)
-        return self.parse_show_columns(relation, rows)
-
-    def _get_columns_for_catalog(self, relation: MySQLRelation) -> Iterable[Dict[str, Any]]:
-        columns = self.get_columns_in_relation(relation)
-
-        for column in columns:
-            # convert MySQLColumns into catalog dicts
-            as_dict = asdict(column)
-            as_dict["column_name"] = as_dict.pop("column", None)
-            as_dict["column_type"] = as_dict.pop("dtype")
-            as_dict["table_database"] = None
-            yield as_dict
+    def get_columns_in_relation(self, relation: BaseRelation) -> List[MySQLColumn]:  # type: ignore[override]
+        columns: List[BaseColumn] = super().get_columns_in_relation(relation)
+        return self.parse_show_columns(relation, columns)
 
     def get_relation(
         self, database: Optional[str], schema: str, identifier: str
@@ -108,7 +97,7 @@ class MySQLAdapter(SQLAdapter):
         return super().get_relation(database, schema, identifier)
 
     def parse_show_columns(
-        self, relation: MySQLRelation, raw_rows: List[agate.Row]
+        self, relation: BaseRelation, raw_columns: List[BaseColumn]
     ) -> List[MySQLColumn]:
         return [
             MySQLColumn(
@@ -118,57 +107,12 @@ class MySQLAdapter(SQLAdapter):
                 table_type=relation.type,
                 table_owner=None,
                 table_stats=None,
-                column=column.column,
+                column=col.column,
                 column_index=idx,
-                dtype=column.dtype,
+                dtype=col.dtype,
             )
-            for idx, column in enumerate(raw_rows)
+            for idx, col in enumerate(raw_columns)
         ]
-
-    def get_catalog(self, manifest: Manifest) -> Tuple[agate.Table, List[Exception]]:
-        schema_map = self._get_catalog_schemas(manifest)
-
-        if len(schema_map) > 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one database in get_catalog, found " f"{list(schema_map)}"
-            )
-
-        with executor(self.config) as tpe:
-            futures: List[Future[agate.Table]] = []
-            for info, schemas in schema_map.items():
-                for schema in schemas:
-                    futures.append(
-                        tpe.submit_connected(
-                            self,
-                            schema,
-                            self._get_one_catalog,
-                            info,
-                            [schema],
-                            manifest,
-                        )
-                    )
-            catalogs, exceptions = catch_as_completed(futures)
-        return catalogs, exceptions
-
-    def _get_one_catalog(
-        self,
-        information_schema,
-        schemas,
-        manifest,
-    ) -> agate.Table:
-        if len(schemas) != 1:
-            raise dbt.exceptions.CompilationError(
-                f"Expected only one schema in mysql5 _get_one_catalog, found " f"{schemas}"
-            )
-
-        database = information_schema.database
-        schema = list(schemas)[0]
-
-        columns: List[Dict[str, Any]] = []
-        for relation in self.list_relations(database, schema):
-            logger.debug("Getting table schema for relation {}", str(relation))
-            columns.extend(self._get_columns_for_catalog(relation))  # type: ignore[arg-type]
-        return agate.Table.from_object(columns, column_types=DEFAULT_TYPE_TESTER)
 
     def check_schema_exists(self, database, schema):
         results = self.execute_macro(LIST_SCHEMAS_MACRO_NAME, kwargs={"database": database})
@@ -207,9 +151,7 @@ class MySQLAdapter(SQLAdapter):
         elif location == "prepend":
             return f"concat({value}, '{add_to}')"
         else:
-            raise dbt.exceptions.DbtRuntimeError(
-                f'Got an unexpected location value of "{location}"'
-            )
+            raise DbtRuntimeError(f'Got an unexpected location value of "{location}"')
 
     def get_rows_different_sql(
         self,

--- a/dbt/adapters/mysql5/relation.py
+++ b/dbt/adapters/mysql5/relation.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
 
 from dbt.adapters.base.relation import BaseRelation, Policy
-from dbt.exceptions import DbtRuntimeError
+from dbt_common.exceptions import DbtRuntimeError
 
 
 @dataclass

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,14 +1,14 @@
-# install latest changes in dbt-core
-# TODO: how to automate switching from develop to version branches?
-git+https://github.com/dbt-labs/dbt-core.git@1.7.latest#egg=dbt-core&subdirectory=core
-git+https://github.com/dbt-labs/dbt-core.git@1.7.latest#egg=dbt-tests-adapter&subdirectory=tests/adapter
+# dbt 1.8 — PyPI pins (adapter split)
+dbt-core~=1.8.0
+dbt-adapters>=1.8.0,<1.9.0
+dbt-common>=1.0.4,<2.0
+dbt-tests-adapter>=1.8.0,<1.9.0
 
 # if version 1.x or greater -> pin to major version
 # if version 0.x -> pin to minor
 black~=24.3
 bumpversion~=0.6.0
 ddtrace~=2.3
-jsonschema<=4.17
 flake8~=6.1
 flaky~=3.7
 freezegun~=1.3

--- a/setup.py
+++ b/setup.py
@@ -51,7 +51,7 @@ def _get_dbt_core_version():
 
 
 package_name = "dbt-mysql"
-package_version = "1.7.0"
+package_version = "1.8.0a1"
 dbt_core_version = _get_dbt_core_version()
 description = """The MySQL adapter plugin for dbt"""
 
@@ -68,6 +68,8 @@ setup(
     include_package_data=True,
     install_requires=[
         "dbt-core~={}".format(dbt_core_version),
+        "dbt-adapters>=1.8.0,<1.9.0",
+        "dbt-common>=1.0.4,<2.0",
         "mysql-connector-python>=8.0.0",
     ],
     zip_safe=False,

--- a/tests/unit/test_adapter.py
+++ b/tests/unit/test_adapter.py
@@ -1,6 +1,7 @@
+import multiprocessing
 import unittest
 from unittest import mock
-import dbt.flags as flags
+
 from dbt.adapters.mysql import MySQLAdapter
 
 from .utils import config_from_parts_or_dicts, mock_connection
@@ -8,8 +9,6 @@ from .utils import config_from_parts_or_dicts, mock_connection
 
 class TestMySQLAdapter(unittest.TestCase):
     def setUp(self):
-        flags.STRICT_MODE = True
-
         profile_cfg = {
             "outputs": {
                 "test": {
@@ -38,11 +37,12 @@ class TestMySQLAdapter(unittest.TestCase):
 
         self.config = config_from_parts_or_dicts(project_cfg, profile_cfg)
         self._adapter = None
+        self.mp_context = multiprocessing.get_context("spawn")
 
     @property
     def adapter(self):
         if self._adapter is None:
-            self._adapter = MySQLAdapter(self.config)
+            self._adapter = MySQLAdapter(self.config, self.mp_context)
         return self._adapter
 
     @mock.patch("dbt.adapters.mysql.connections.mysql.connector")


### PR DESCRIPTION
Upgrade to 1.8.0 (closes #170)

### Description

- `dbt-core` 1.8.7 installed
- Import paths -> dbt.adapters.* / dbt_common.*
- Credentials -> plain dataclass
- Removed legacy get_catalog(manifest) overrides
- Catalog filter for null table_database (docs generate)
- Unit test multiprocessing context
- Typing/import fixes (BaseColumn, connections dict index, etc.)


### Checklist
 - [X] I have run this code in development and it appears to resolve the stated issue
 - [X] No new tests added
 - [x] I have updated the `CHANGELOG.md` with information about my change
